### PR TITLE
args now getting ignored in `filter_ids_text`

### DIFF
--- a/filtering/processor.py
+++ b/filtering/processor.py
@@ -378,7 +378,7 @@ class Filter(flutes.PoolState):
         Used by filtering/filter_ids.py.
         """
         # ignore irrelevant entry (cf. filter_ids.py)
-        file_, _ = file_
+        file_, *_ = file_
 
         with gzip.open(str(file_), "r") as f:
             # metadata_ID.jsonl.gz


### PR DESCRIPTION
Previous version failed to properly ignore extra arguments `filter_ids.py` passes to `filter_ids_text`. `_` was just capturing one instead of 4, which lead to the pre-processing script crashing.